### PR TITLE
Allow printing to stderr instead of stdout

### DIFF
--- a/nom-tracable/Cargo.toml
+++ b/nom-tracable/Cargo.toml
@@ -21,6 +21,7 @@ pre-release-replacements = [
 [features]
 default = []
 trace   = []
+stderr  = []
 
 [dependencies]
 nom                 = "7"

--- a/nom-tracable/examples/u8_custom_parser.rs
+++ b/nom-tracable/examples/u8_custom_parser.rs
@@ -1,7 +1,5 @@
 use nom::branch::*;
 use nom::character::complete::*;
-#[cfg(feature = "trace")]
-use nom::{AsBytes, Offset};
 use nom::{IResult, InputIter, Needed, Slice};
 use nom_locate::LocatedSpan;
 use nom_tracable::{cumulative_histogram, histogram, tracable_parser, TracableInfo};

--- a/nom-tracable/src/lib.rs
+++ b/nom-tracable/src/lib.rs
@@ -594,6 +594,15 @@ pub fn forward_trace<T: Tracable>(input: T, name: &str) -> (TracableInfo, T) {
 
         let control_witdh = if info.color { 11 } else { 0 };
 
+        #[cfg(feature = "stderr")]
+        eprintln!(
+            "\n{} : {:<parser_width$} : {}",
+            forward_backword,
+            "parser",
+            input.header(),
+            parser_width = info.parser_width - control_witdh,
+        );
+        #[cfg(not(feature = "stderr"))]
         println!(
             "\n{} : {:<parser_width$} : {}",
             forward_backword,
@@ -628,6 +637,22 @@ pub fn forward_trace<T: Tracable>(input: T, name: &str) -> (TracableInfo, T) {
         let reset = if info.color { "\u{001b}[0m" } else { "" };
         let folded = if info.folded(name) { "+" } else { " " };
 
+        #[cfg(feature = "stderr")]
+        eprintln!(
+            "{} : {:<parser_width$} : {}",
+            forward_backword,
+            format!(
+                "{}{}-> {} {}{}",
+                color,
+                " ".repeat(depth),
+                name,
+                folded,
+                reset
+            ),
+            input.format(),
+            parser_width = info.parser_width,
+        );
+        #[cfg(not(feature = "stderr"))]
         println!(
             "{} : {:<parser_width$} : {}",
             forward_backword,
@@ -704,6 +729,22 @@ pub fn backward_trace<T: Tracable, U, V>(
 
         match input {
             Ok((s, x)) => {
+                #[cfg(feature = "stderr")]
+                eprintln!(
+                    "{} : {:<parser_width$} : {}",
+                    forward_backword,
+                    format!(
+                        "{}{}<- {} {}{}",
+                        color_ok,
+                        " ".repeat(depth),
+                        name,
+                        folded,
+                        reset
+                    ),
+                    s.format(),
+                    parser_width = info.parser_width,
+                );
+                #[cfg(not(feature = "stderr"))]
                 println!(
                     "{} : {:<parser_width$} : {}",
                     forward_backword,
@@ -733,6 +774,21 @@ pub fn backward_trace<T: Tracable, U, V>(
                 Ok((s.dec_depth(), x))
             }
             Err(x) => {
+                #[cfg(feature = "stderr")]
+                eprintln!(
+                    "{} : {:<parser_width$}",
+                    forward_backword,
+                    format!(
+                        "{}{}<- {} {}{}",
+                        color_err,
+                        " ".repeat(depth),
+                        name,
+                        folded,
+                        reset
+                    ),
+                    parser_width = info.parser_width,
+                );
+                #[cfg(not(feature = "stderr"))]
                 println!(
                     "{} : {:<parser_width$}",
                     forward_backword,
@@ -771,6 +827,15 @@ pub fn custom_trace<T: Tracable>(input: &T, name: &str, message: &str, color: &s
         let color = if info.color { color } else { "" };
         let reset = if info.color { "\u{001b}[0m" } else { "" };
 
+        #[cfg(feature = "stderr")]
+        eprintln!(
+            "{} : {:<parser_width$} : {}",
+            forward_backword,
+            format!("{}{}   {}{}", color, " ".repeat(depth), name, reset),
+            message,
+            parser_width = info.parser_width,
+        );
+        #[cfg(not(feature = "stderr"))]
         println!(
             "{} : {:<parser_width$} : {}",
             forward_backword,

--- a/nom-tracable/src/lib.rs
+++ b/nom-tracable/src/lib.rs
@@ -585,7 +585,8 @@ pub fn forward_trace<T: Tracable>(input: T, name: &str) -> (TracableInfo, T) {
             "parser",
             input.header(),
             parser_width = info.parser_width - control_witdh,
-        );
+        )
+        .unwrap();
     }
 
     if info.forward {
@@ -627,7 +628,8 @@ pub fn forward_trace<T: Tracable>(input: T, name: &str) -> (TracableInfo, T) {
             ),
             input.format(),
             parser_width = info.parser_width,
-        );
+        )
+        .unwrap();
     }
 
     crate::TRACABLE_STORAGE.with(|storage| {
@@ -710,7 +712,8 @@ pub fn backward_trace<T: Tracable, U, V>(
                     ),
                     s.format(),
                     parser_width = info.parser_width,
-                );
+                )
+                .unwrap();
 
                 let s = if info.folded(name) {
                     let info = s
@@ -739,7 +742,8 @@ pub fn backward_trace<T: Tracable, U, V>(
                         reset
                     ),
                     parser_width = info.parser_width,
-                );
+                )
+                .unwrap();
                 Err(x)
             }
         }
@@ -778,6 +782,7 @@ pub fn custom_trace<T: Tracable>(input: &T, name: &str, message: &str, color: &s
             format!("{}{}   {}{}", color, " ".repeat(depth), name, reset),
             message,
             parser_width = info.parser_width,
-        );
+        )
+        .unwrap();
     }
 }

--- a/nom-tracable/src/lib.rs
+++ b/nom-tracable/src/lib.rs
@@ -475,7 +475,6 @@ fn cumulative_histogram_internal() {
 #[cfg(not(feature = "trace"))]
 fn cumulative_histogram_internal() {}
 
-#[cfg(not(feature = "stderr"))]
 #[allow(dead_code)]
 fn show_histogram(title: &str, map: &HashMap<String, usize>) {
     let mut result = Vec::new();
@@ -525,59 +524,9 @@ fn show_histogram(title: &str, map: &HashMap<String, usize>) {
     println!("");
 }
 
-#[cfg(feature = "stderr")]
-#[allow(dead_code)]
-fn show_histogram(title: &str, map: &HashMap<String, usize>) {
-    let mut result = Vec::new();
-    let mut max_parser_len = "parser".len();
-    let mut max_count = 0;
-    let mut max_count_len = "count".len();
-    for (p, c) in map {
-        result.push((p, c));
-        max_parser_len = max_parser_len.max(p.len());
-        max_count = max_count.max(*c);
-        max_count_len = max_count_len.max(format!("{}", c).len());
-    }
-
-    result.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap());
-
-    let bar_length = 50;
-
-    eprintln!(
-        "\n{:<parser$} | {:<bar$} | {}",
-        "parser",
-        title,
-        "count",
-        parser = max_parser_len,
-        bar = bar_length,
-    );
-    eprintln!(
-        "{:<parser$} | {:<bar$} | {}",
-        "-".repeat(max_parser_len),
-        "-".repeat(bar_length),
-        "-".repeat(max_count_len),
-        parser = max_parser_len,
-        bar = bar_length,
-    );
-    for (p, c) in &result {
-        let bar = *c * bar_length / max_count;
-        if bar > 0 {
-            eprintln!(
-                "{:<parser$} | {}{} | {}",
-                p,
-                ".".repeat(bar),
-                " ".repeat(bar_length - bar),
-                c,
-                parser = max_parser_len,
-            );
-        }
-    }
-    eprintln!("");
-}
-
 /// Function to display forward trace.
 /// This is inserted by `#[tracable_parser]`.
-#[cfg(all(feature = "trace", not(feature = "stderr")))]
+#[cfg(feature = "trace")]
 pub fn forward_trace<T: Tracable>(input: T, name: &str) -> (TracableInfo, T) {
     let info = input.get_tracable_info();
     let depth = info.depth;
@@ -676,110 +625,9 @@ pub fn forward_trace<T: Tracable>(input: T, name: &str) -> (TracableInfo, T) {
     (info, input)
 }
 
-/// Function to display forward trace.
-/// This is inserted by `#[tracable_parser]`.
-#[cfg(all(feature = "trace", feature = "stderr"))]
-pub fn forward_trace<T: Tracable>(input: T, name: &str) -> (TracableInfo, T) {
-    let info = input.get_tracable_info();
-    let depth = info.depth;
-
-    if depth == 0 {
-        crate::TRACABLE_STORAGE.with(|storage| {
-            storage.borrow_mut().init();
-        });
-        let forward_backword = if info.forward & info.backward {
-            format!(
-                "{:<count_width$} {:<count_width$}",
-                "forward",
-                "backward",
-                count_width = info.count_width
-            )
-        } else if info.forward {
-            format!(
-                "{:<count_width$}",
-                "forward",
-                count_width = info.count_width
-            )
-        } else {
-            format!(
-                "{:<count_width$}",
-                "backward",
-                count_width = info.count_width
-            )
-        };
-
-        let control_witdh = if info.color { 11 } else { 0 };
-
-        eprintln!(
-            "\n{} : {:<parser_width$} : {}",
-            forward_backword,
-            "parser",
-            input.header(),
-            parser_width = info.parser_width - control_witdh,
-        );
-    }
-
-    if info.forward {
-        let forward_count = crate::TRACABLE_STORAGE.with(|storage| {
-            storage.borrow_mut().inc_forward_count();
-            storage.borrow().get_forward_count()
-        });
-
-        let forward_backword = if info.backward {
-            format!(
-                "{:<count_width$} {:<count_width$}",
-                forward_count,
-                "",
-                count_width = info.count_width
-            )
-        } else {
-            format!(
-                "{:<count_width$}",
-                forward_count,
-                count_width = info.count_width
-            )
-        };
-
-        let color = if info.color { "\u{001b}[1;37m" } else { "" };
-        let reset = if info.color { "\u{001b}[0m" } else { "" };
-        let folded = if info.folded(name) { "+" } else { " " };
-
-        eprintln!(
-            "{} : {:<parser_width$} : {}",
-            forward_backword,
-            format!(
-                "{}{}-> {} {}{}",
-                color,
-                " ".repeat(depth),
-                name,
-                folded,
-                reset
-            ),
-            input.format(),
-            parser_width = info.parser_width,
-        );
-    }
-
-    crate::TRACABLE_STORAGE.with(|storage| {
-        storage.borrow_mut().inc_histogram(name);
-        storage.borrow_mut().add_cumulative(name, depth);
-        storage.borrow_mut().inc_cumulative();
-    });
-
-    let input = if info.folded(name) {
-        let info = info.forward(false).backward(false).custom(false);
-        input.set_tracable_info(info)
-    } else {
-        input
-    };
-
-    let input = input.inc_depth();
-    (info, input)
-}
-
 /// Function to display backward trace.
 /// This is inserted by `#[tracable_parser]`.
-#[cfg(all(feature = "trace", not(feature = "stderr")))]
+#[cfg(feature = "trace")]
 pub fn backward_trace<T: Tracable, U, V>(
     input: IResult<T, U, V>,
     name: &str,
@@ -850,99 +698,6 @@ pub fn backward_trace<T: Tracable, U, V>(
             }
             Err(x) => {
                 println!(
-                    "{} : {:<parser_width$}",
-                    forward_backword,
-                    format!(
-                        "{}{}<- {} {}{}",
-                        color_err,
-                        " ".repeat(depth),
-                        name,
-                        folded,
-                        reset
-                    ),
-                    parser_width = info.parser_width,
-                );
-                Err(x)
-            }
-        }
-    } else {
-        input
-    }
-}
-
-/// Function to display backward trace.
-/// This is inserted by `#[tracable_parser]`.
-#[cfg(all(feature = "trace", feature = "stderr"))]
-pub fn backward_trace<T: Tracable, U, V>(
-    input: IResult<T, U, V>,
-    name: &str,
-    info: TracableInfo,
-) -> IResult<T, U, V> {
-    let depth = info.depth;
-
-    crate::TRACABLE_STORAGE.with(|storage| {
-        let cnt = *storage.borrow_mut().get_cumulative(name, depth).unwrap();
-        storage.borrow_mut().inc_cumulative_histogram(name, cnt);
-    });
-
-    if info.backward {
-        let backward_count = crate::TRACABLE_STORAGE.with(|storage| {
-            storage.borrow_mut().inc_backward_count();
-            storage.borrow().get_backward_count()
-        });
-
-        let forward_backword = if info.forward {
-            format!(
-                "{:<count_width$} {:<count_width$}",
-                "",
-                backward_count,
-                count_width = info.count_width
-            )
-        } else {
-            format!(
-                "{:<count_width$}",
-                backward_count,
-                count_width = info.count_width
-            )
-        };
-
-        let color_ok = if info.color { "\u{001b}[1;32m" } else { "" };
-        let color_err = if info.color { "\u{001b}[1;31m" } else { "" };
-        let reset = if info.color { "\u{001b}[0m" } else { "" };
-        let folded = if info.folded(name) { "+" } else { " " };
-
-        match input {
-            Ok((s, x)) => {
-                eprintln!(
-                    "{} : {:<parser_width$} : {}",
-                    forward_backword,
-                    format!(
-                        "{}{}<- {} {}{}",
-                        color_ok,
-                        " ".repeat(depth),
-                        name,
-                        folded,
-                        reset
-                    ),
-                    s.format(),
-                    parser_width = info.parser_width,
-                );
-
-                let s = if info.folded(name) {
-                    let info = s
-                        .get_tracable_info()
-                        .forward(info.forward)
-                        .backward(info.backward)
-                        .custom(info.custom);
-                    s.set_tracable_info(info)
-                } else {
-                    s
-                };
-
-                Ok((s.dec_depth(), x))
-            }
-            Err(x) => {
-                eprintln!(
                     "{} : {:<parser_width$}",
                     forward_backword,
                     format!(
@@ -964,7 +719,7 @@ pub fn backward_trace<T: Tracable, U, V>(
 }
 
 /// Function to display custom trace.
-#[cfg(all(feature = "trace", not(feature = "stderr")))]
+#[cfg(feature = "trace")]
 pub fn custom_trace<T: Tracable>(input: &T, name: &str, message: &str, color: &str) {
     let info = input.get_tracable_info();
 
@@ -981,33 +736,6 @@ pub fn custom_trace<T: Tracable>(input: &T, name: &str, message: &str, color: &s
         let reset = if info.color { "\u{001b}[0m" } else { "" };
 
         println!(
-            "{} : {:<parser_width$} : {}",
-            forward_backword,
-            format!("{}{}   {}{}", color, " ".repeat(depth), name, reset),
-            message,
-            parser_width = info.parser_width,
-        );
-    }
-}
-
-/// Function to display custom trace.
-#[cfg(all(feature = "trace", feature = "stderr"))]
-pub fn custom_trace<T: Tracable>(input: &T, name: &str, message: &str, color: &str) {
-    let info = input.get_tracable_info();
-
-    if info.custom {
-        let depth = info.depth;
-        let forward_backword = format!(
-            "{:<count_width$} {:<count_width$}",
-            "",
-            "",
-            count_width = info.count_width
-        );
-
-        let color = if info.color { color } else { "" };
-        let reset = if info.color { "\u{001b}[0m" } else { "" };
-
-        eprintln!(
             "{} : {:<parser_width$} : {}",
             forward_backword,
             format!("{}{}   {}{}", color, " ".repeat(depth), name, reset),

--- a/nom-tracable/src/lib.rs
+++ b/nom-tracable/src/lib.rs
@@ -492,6 +492,16 @@ fn show_histogram(title: &str, map: &HashMap<String, usize>) {
 
     let bar_length = 50;
 
+    #[cfg(feature = "stderr")]
+    eprintln!(
+        "\n{:<parser$} | {:<bar$} | {}",
+        "parser",
+        title,
+        "count",
+        parser = max_parser_len,
+        bar = bar_length,
+    );
+    #[cfg(not(feature = "stderr"))]
     println!(
         "\n{:<parser$} | {:<bar$} | {}",
         "parser",
@@ -500,7 +510,9 @@ fn show_histogram(title: &str, map: &HashMap<String, usize>) {
         parser = max_parser_len,
         bar = bar_length,
     );
-    println!(
+
+    #[cfg(feature = "stderr")]
+    eprintln!(
         "{:<parser$} | {:<bar$} | {}",
         "-".repeat(max_parser_len),
         "-".repeat(bar_length),
@@ -508,9 +520,29 @@ fn show_histogram(title: &str, map: &HashMap<String, usize>) {
         parser = max_parser_len,
         bar = bar_length,
     );
+    #[cfg(not(feature = "stderr"))]
+    println!(
+        "\n{:<parser$} | {:<bar$} | {}",
+        "parser",
+        title,
+        "count",
+        parser = max_parser_len,
+        bar = bar_length,
+    );
+
     for (p, c) in &result {
         let bar = *c * bar_length / max_count;
         if bar > 0 {
+            #[cfg(feature = "stderr")]
+            eprintln!(
+                "{:<parser$} | {}{} | {}",
+                p,
+                ".".repeat(bar),
+                " ".repeat(bar_length - bar),
+                c,
+                parser = max_parser_len,
+            );
+            #[cfg(not(feature = "stderr"))]
             println!(
                 "{:<parser$} | {}{} | {}",
                 p,
@@ -521,7 +553,11 @@ fn show_histogram(title: &str, map: &HashMap<String, usize>) {
             );
         }
     }
-    println!("");
+    if cfg!(feature = "stderr") {
+        eprintln!("");
+    } else {
+        println!("")
+    }
 }
 
 /// Function to display forward trace.


### PR DESCRIPTION
This should fix #12 in at least a pretty bare form by allowing consumers to select a non-default feature (to prevent breakage in existing setups) that makes all print statements output to stderr instead.

I wish we could conditionally compile in single lines; I opted for duplicating at the block level because the alternative requires formatting before output selection and then formatting _again_ when writing output.

The only other change I made was to silence a `rustc` warning about unused imports in the example